### PR TITLE
Add Live Demo Link

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,9 @@
 - Figma
 - VSCode
 
+## Live Demo Link:
 
+[Live Demo Link](https://shedrack-sunday.github.io/Portfolio-Project/)
 
 ## Authors
 


### PR DESCRIPTION
GitHub pages was used to enable live link of the portfolio project.